### PR TITLE
Improved the Icon Overlapping Error

### DIFF
--- a/src/user/dashboard/navigation/navigation.js
+++ b/src/user/dashboard/navigation/navigation.js
@@ -14,8 +14,8 @@ class Navigation extends Component {
       logout:false
     });
     const divStyle = {
-      position: "absolute",
-      bottom: 0
+      position: "relative",
+      bottom: "-15em"
     };
 
     return (


### PR DESCRIPTION
Fixes issue number #357

**Result**
Now the setting and logout icons are aligned

**Screenshot**
![settinglog](https://user-images.githubusercontent.com/48439116/76170519-99259b00-61a8-11ea-83cb-3c2596331cf6.jpg)
