### PR TITLE
styling fix

### DIFF
--- a/src/user/events/events.js
+++ b/src/user/events/events.js
@@ -276,13 +276,13 @@ class Events extends Component {
         <div className="navigation">
           <Navigation event={this.state.event}></Navigation>
         </div>
-        <div className="events">
-          <h1 className="event_header">All Events</h1>
+        <div className="news projects">
+          <p className="event_header">All Events</p>
           <Grid container spacing={3}>
             {Events}
           </Grid>
 
-          <div className="event__pagination__container">
+          <div className="project__pagination__container">
             <Pagination
               showSizeChanger
               onShowSizeChange={this.onShowSizeChange}

--- a/src/user/events/events.scss
+++ b/src/user/events/events.scss
@@ -1,8 +1,7 @@
 .organization {
   display: flex;
-  min-height: 100vh;
-  height: auto;
-  font-family: Muli, sans-serif;
+    min-height: 100vh;
+    font-family: Muli, sans-serif;
   .navigation {
     background: #f5f5f5;
     flex-grow: 1;
@@ -34,12 +33,12 @@
       height: 42vh;
     }
 
-    .event__pagination__container {
+    .project__pagination__container {
       display: flex;
+      padding-top: 20px;
       flex-direction: row;
       justify-content: center;
       align-items: center;
-      padding-top: 29px;
     }
   }
 }
@@ -163,3 +162,22 @@
     color: #1a73ed;
   }
 }
+
+      .event__header {
+        font-family: Inter;
+        font-style: normal;
+        font-weight: normal;
+        font-size: 1.5em;
+        line-height: 1.3em;
+        color: #2D2D2D;
+      }
+
+      
+
+    .event__pagination__container {
+      display: flex;
+      padding-top: 20px;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+    }

--- a/src/user/organization/organization.scss
+++ b/src/user/organization/organization.scss
@@ -3,6 +3,7 @@
   min-height: 100vh;
   height: auto;
   font-family: "Inter";
+  padding-left: 20px;
   .navigation {
     overflow-y: scroll;
     background: #f5f5f5;

--- a/src/user/projects/projects.js
+++ b/src/user/projects/projects.js
@@ -99,7 +99,7 @@ class Projects extends Component {
           <Navigation proj={this.state.proj}></Navigation>
         </div>
         <div className="news projects">
-          <p id="project__header">All Projects</p>
+          <p className="project__header">All Projects</p>
           <div className={useStyles.root}>
             <Grid container spacing={3}>
               {Projects}

--- a/src/user/projects/projects.scss
+++ b/src/user/projects/projects.scss
@@ -12,9 +12,9 @@
     }
 
     .projects {
-        margin-top: 1vh;
-        margin-left: 4vw;
-        margin-right: 6vw;
+      padding: 20px;
+      margin-top: 2vh;
+      margin-left: 4vw;
         p {
           font-family: Inter;
           font-style: normal;
@@ -23,7 +23,7 @@
           line-height: 1.3em;
           color: #2D2D2D;
         }
-        #project_header {
+        .project__header {
           font-family: Inter;
           font-style: normal;
           font-weight: normal;


### PR DESCRIPTION
fixes #610 
fixed the colliding style of preloader in navbar-> organisation
before:
![chrome_FHZUWWlQDi](https://user-images.githubusercontent.com/54861487/92404220-a79d4100-f150-11ea-8b46-c51c59ccaeb0.png)
after:
![chrome_gxgDk47t3l](https://user-images.githubusercontent.com/54861487/92404231-ac61f500-f150-11ea-873a-96e086a7f30d.png)
