### PR TITLE
styling fix

### DIFF
--- a/src/user/organization/organization.scss
+++ b/src/user/organization/organization.scss
@@ -3,6 +3,7 @@
   min-height: 100vh;
   height: auto;
   font-family: "Inter";
+  padding-left: 20px;
   .navigation {
     overflow-y: scroll;
     background: #f5f5f5;


### PR DESCRIPTION
fixes #610 
fixed the colliding style of preloader in navbar-> organisation
before:
![chrome_FHZUWWlQDi](https://user-images.githubusercontent.com/54861487/92404220-a79d4100-f150-11ea-8b46-c51c59ccaeb0.png)
after:
![chrome_gxgDk47t3l](https://user-images.githubusercontent.com/54861487/92404231-ac61f500-f150-11ea-873a-96e086a7f30d.png)
